### PR TITLE
move requirements to requirements.txt

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,30 +30,6 @@ dependencies:
   # Base dependencies
   - pip
   - python>=3.7
-  - Cython
-  - numpy>=1.13
-  - scipy
-  - matplotlib>=3.1.1
-  - astropy
-  - jupyter
-  - notebook
-
-  # Dependencies
-  - photutils>=1.1.0
-  - ipywidgets
-
-  # Docs
-  - sphinx
-  - docutils
-  - nbsphinx
-
 
   - pip:
-    - tox
-
-    # Docs
-    - astropy_helpers
-    - extension_helpers
-    - sphinx_astropy
-    - sphinx_rtd_theme
-    - sphinx-automodapi
+    - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ nbsphinx
 
 # Other
 tox
+skimage
 sklearn
 astropy_helpers
 extension_helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ nbsphinx
 
 # Other
 tox
+sklearn
 astropy_helpers
 extension_helpers
 sphinx_astropy

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ nbsphinx
 
 # Other
 tox
-skimage
+scikit-image
 sklearn
 astropy_helpers
 extension_helpers

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,25 @@
+# Core Dependencies
+Cython
+numpy>=1.13
+scipy
+matplotlib>=3.1.1
+astropy
+jupyter
+notebook
+
+# Dependencies
+photutils>=1.1.0
+ipywidgets
+
+# Docs
+sphinx
+docutils
+nbsphinx
+
+# Other
+tox
+astropy_helpers
+extension_helpers
+sphinx_astropy
+sphinx_rtd_theme
+sphinx-automodapi


### PR DESCRIPTION
close #71 

Moved requirements to `requirements.txt` because conda is taking too much memory to resolve packages. This is causing RTD docs to fail building. 