### PR TITLE
Restrict Astropy Requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Cython
 numpy>=1.13
 scipy
 matplotlib>=3.1.1
-astropy
+astropy>=5.0.3
 jupyter
 notebook
 


### PR DESCRIPTION
closes #96 

Astropy 5.0.3 has been released, making bug fixes available. 