### PR TITLE
Change CI Testing to `tox`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,13 +37,11 @@ jobs:
           command: conda env create -f environment.yml
 
       - run:
-          name: Activate petrofit
+          name: Run Tests
           # This assumes pytest is installed via the install-package step above
           command: |
             conda init bash
             source ~/.bashrc
-            conda activate petrofit 
-
-      - run:
-          name: Run tox Tests
-          command: tox
+            conda activate petrofit
+            pip install tox
+            tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,4 +44,5 @@ jobs:
             source ~/.bashrc
             conda activate petrofit
             pip install tox
+            pip install cython
             tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,10 +37,13 @@ jobs:
           command: conda env create -f environment.yml
 
       - run:
-          name: Run tests
+          name: Activate petrofit
           # This assumes pytest is installed via the install-package step above
           command: |
             conda init bash
             source ~/.bashrc
             conda activate petrofit 
-            pytest
+
+      - run:
+          name: Run tox Tests
+          command: tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,5 +44,4 @@ jobs:
             source ~/.bashrc
             conda activate petrofit
             pip install tox
-            pip install cython
             tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
   # Orb commands and jobs help you with common scripting around a language/tool
   # so you dont have to copy and paste it everywhere.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
-  python: circleci/python@1.2
+  python: circleci/python@2.0.3
 
 workflows:
   pytest-all:  # This is the name of the workflow, feel free to change it to better match your workflow.

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
 envlist =
-    py{python3.10}-test{-alldeps,-devdeps}
+    py{python3.10}-test{-alldeps}
     py{python3.10}-test-numpy{122}
     py{python3.10}-test-astropy{503}
     build_docs
-#    linkcheck # Disabled until cleanup
+    linkcheck 
 #    codestyle # Disabled until cleanup
 requires =
     setuptools >= 61.0.0
@@ -79,7 +79,7 @@ description = check the links in the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -W -b linkcheck . _build/html
+    sphinx-build -b linkcheck . _build/html
 
 [testenv:codestyle]
 skip_install = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{36,37,38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{36,37,38,39}-test-numpy{116,117,118}
-    py{36,37,38,39}-test-astropy{30,40,lts}
+    py{38,39}-test{,-alldeps,-devdeps}{,-cov}
+    py{38,39}-test-numpy{116,117,118}
+    py{38,39}-test-astropy{503,lts}
     build_docs
     linkcheck
     codestyle
@@ -41,21 +41,19 @@ description =
     numpy116: with numpy 1.16.*
     numpy117: with numpy 1.17.*
     numpy118: with numpy 1.18.*
-    astropy30: with astropy 3.0.*
-    astropy40: with astropy 4.0.*
+    astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
 # The following provides some specific pinnings for key packages
 deps =
-
+    -r{toxinidir}/requirements.txt
     cov: coverage
     numpy116: numpy==1.16.*
     numpy117: numpy==1.17.*
     numpy118: numpy==1.18.*
 
-    astropy30: astropy==3.0.*
-    astropy40: astropy==4.0.*
-    astropylts: astropy==4.0.*
+    astropy50: astropy==5.0.*
+    astropylts: astropy==5.0.*
 
     devdeps: :NIGHTLY:numpy
     devdeps: git+https://github.com/astropy/astropy.git#egg=astropy

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist =
     py{python3.10}-test-numpy{122}
     py{python3.10}-test-astropy{503}
     build_docs
-    linkcheck 
+#    linkcheck 
 #    codestyle # Disabled until cleanup
 requires =
     setuptools >= 61.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{38,39}-test{,-alldeps,-devdeps}{,-cov}
-    py{38,39}-test-numpy{116,117,118}
-    py{38,39}-test-astropy{503,lts}
+    py{python3.8,python3.9,python3.10}-test{,-alldeps,-devdeps}{,-cov}
+    py{python3.8,python3.9,python3.10}-test-numpy{116,117,118}
+    py{python3.8,python3.9,python3.10}-test-astropy{503,lts}
     build_docs
     linkcheck
     codestyle

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     py{python3.10}-test-numpy{122}
     py{python3.10}-test-astropy{503}
     build_docs
-    linkcheck
-    codestyle
+#    linkcheck # Disabled until cleanup
+#    codestyle # Disabled until cleanup
 requires =
     setuptools >= 61.0.0
     pip >= 22.0.0
@@ -71,7 +71,7 @@ description = invoke sphinx-build to build the HTML docs
 extras = docs
 commands =
     pip freeze
-    sphinx-build -W -b html . _build/html
+    sphinx-build -b html . _build/html
 
 [testenv:linkcheck]
 changedir = docs

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist =
-    py{python3.9,python3.10}-test{,-alldeps,-devdeps}{,-cov}
+    py{python3.10}-test{-alldeps,-devdeps}
     py{python3.10}-test-numpy{122}
-    py{python3.10}-test-astropy{503,lts}
+    py{python3.10}-test-astropy{503}
     build_docs
     linkcheck
     codestyle
 requires =
-    setuptools >= 30.3.0
-    pip >= 19.3.1
+    setuptools >= 61.0.0
+    pip >= 22.0.0
 isolated_build = true
 indexserver =
     NIGHTLY = https://pypi.anaconda.org/scipy-wheels-nightly/simple

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 [tox]
 envlist =
-    py{python3.8,python3.9,python3.10}-test{,-alldeps,-devdeps}{,-cov}
-    py{python3.8,python3.9,python3.10}-test-numpy{116,117,118}
-    py{python3.8,python3.9,python3.10}-test-astropy{503,lts}
+    py{python3.9,python3.10}-test{,-alldeps,-devdeps}{,-cov}
+    py{python3.10}-test-numpy{122}
+    py{python3.10}-test-astropy{503,lts}
     build_docs
     linkcheck
     codestyle
@@ -38,9 +38,7 @@ description =
     devdeps: with the latest developer version of key dependencies
     oldestdeps: with the oldest supported version of key dependencies
     cov: and test coverage
-    numpy116: with numpy 1.16.*
-    numpy117: with numpy 1.17.*
-    numpy118: with numpy 1.18.*
+    numpy122: with numpy 1.22.*
     astropy50: with astropy 5.0.*
     astropylts: with the latest astropy LTS
 
@@ -48,9 +46,7 @@ description =
 deps =
     -r{toxinidir}/requirements.txt
     cov: coverage
-    numpy116: numpy==1.16.*
-    numpy117: numpy==1.17.*
-    numpy118: numpy==1.18.*
+    numpy122: numpy==1.22.*
 
     astropy50: astropy==5.0.*
     astropylts: astropy==5.0.*


### PR DESCRIPTION
Right now the CI is using `pytest` to run tests, this PR changes it to `tox`