### PR TITLE
Update CircleCI config 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,47 +1,23 @@
 version: 2.1
 
 orbs:
-  # The python orb contains a set of prepackaged CircleCI configuration you can use repeatedly in your configuration files
-  # Orb commands and jobs help you with common scripting around a language/tool
-  # so you dont have to copy and paste it everywhere.
-  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/python
   python: circleci/python@2.0.3
 
 workflows:
-  pytest-all:  # This is the name of the workflow, feel free to change it to better match your workflow.
-    # Inside the workflow, you define the jobs you want to run. 
-    # For more details on extending your workflow, see the configuration docs: https://circleci.com/docs/2.0/configuration-reference/#workflows 
+  pytest-all:
     jobs:
       - build-and-test
 
-
 jobs:
-  build-and-test:  # This is the name of the job, feel free to change it to better match what you're trying to do!
-    # These next lines defines a Docker executors: https://circleci.com/docs/2.0/executor-types/
-    # You can specify an image from Dockerhub or use one of the convenience images from CircleCI's Developer Hub
-    # A list of available CircleCI Docker convenience images are available here: https://circleci.com/developer/images/image/cimg/python
-    # The executor is the environment in which the steps below will be executed - below will use a python 3.9 container
-    # Change the version below to your required version of python
-    docker:
-      - image: continuumio/miniconda3:latest
-    # Checkout the code as the first step. This is a dedicated CircleCI step.
-    # The python orb's install-packages step will install the dependencies from a Pipfile via Pipenv by default.
-    # Here we're making sure we use just use the system-wide pip. By default it uses the project root's requirements.txt.
-    # Then run your tests!
-    # CircleCI will report the results back to your VCS provider.
+  build-and-test:
     resource_class: medium+
+    docker:
+      - image: jupyter/scipy-notebook:4d9c9bd9ced0
     steps:
       - checkout
       - run:
-          name: conda install
-          command: conda env create -f environment.yml
-
+          name: Install tox
+          command: pip install tox
       - run:
           name: Run Tests
-          # This assumes pytest is installed via the install-package step above
-          command: |
-            conda init bash
-            source ~/.bashrc
-            conda activate petrofit
-            pip install tox
-            tox
+          command: tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ nbsphinx
 # Other
 tox
 scikit-image
-sklearn
+scikit-learn
 astropy_helpers
 extension_helpers
 sphinx_astropy


### PR DESCRIPTION
CircleCI started failing recently and upon inspection, it was clear that the build should be simplified. As such, this PR removes the conda commands and only uses tox to install dependencies. 