### PR TITLE
Freeze tox to 3.25.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - checkout
       - run:
           name: Install tox
-          command: pip install tox
+          command: pip install tox==3.25.1
       - run:
           name: Run Tests
           command: tox

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-test:
     resource_class: medium+
     docker:
-      - image: jupyter/scipy-notebook:4d9c9bd9ced0
+      - image: jupyter/scipy-notebook:python-3.10
     steps:
       - checkout
       - run:

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ indexserver =
 setenv = MPLBACKEND=agg
 
 # Pass through the following environment variables which may be needed for the CI
-passenv = HOME WINDIR LC_ALL LC_CTYPE CC CI TRAVIS
+passenv = *
 
 # Run the tests in a temporary directory to make sure that we don't import
 # this package from the source tree


### PR DESCRIPTION
`tox.ini` file needs to be updated to the latest format. Freezing tox to 3.25.1 for now (#173 will track a future fix to this)