### PR TITLE
Change sklearn to scikit-learn

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ install_requires =
     astropy
     scipy
     pyyaml
-    sklearn
+    scikit-learn
     scikit-image
     photutils
 


### PR DESCRIPTION
Installing with pip throws an error:

"The 'sklearn' PyPI package is deprecated, use 'scikit-learn' rather than 'sklearn' for pip commands. Here is how to fix this error in the main use cases: (...)
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
(...)
      More information is available at
      https://github.com/scikit-learn/sklearn-pypi-package"

As far as I can see, this is the only place that uses sklearn instead of scikit-learn; after this change, the package installs fine. Feel free to disregard and sorry if this is wrong!