### PR TITLE
Remove DecisionTreeRegressor

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -27,7 +27,7 @@ jobs:
 
           - os: ubuntu-latest
             python: '3.10'
-            tox_env: 'py310-test-astropy50'
+            tox_env: 'py310-test-astropy53'
             allow_failure: false
             prefix: ''
 

--- a/petrofit/petrosian/core.py
+++ b/petrofit/petrosian/core.py
@@ -1,12 +1,8 @@
-import yaml
-
 import numpy as np
 
 from scipy.interpolate import interp1d
 
 from matplotlib import pyplot as plt
-
-from sklearn.tree import DecisionTreeRegressor
 
 from ..utils import closest_value_index, get_interpolated_values, pixel_to_angular, mpl_tick_frame
 from ..photometry import radial_elliptical_aperture


### PR DESCRIPTION
closes #174 , closes #119

`DecisionTreeRegressor` was not removed during the first Petro refactor. This PR removes all references. 