### PR TITLE
pyOpenSci Initial Updates and Upgrades

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -15,33 +15,29 @@ jobs:
   tests:
     name: ${{ matrix.prefix }} ${{ matrix.os }}, ${{ matrix.tox_env }}
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow_failure }}
+    continue-on-error: false
     strategy:
       matrix:
         include:
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-alldeps'
-            allow_failure: false
-            prefix: ''
+            prefix: 'py310-test-alldeps'
 
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-astropy53'
-            allow_failure: false
-            prefix: ''
+            prefix: 'py310-test-astropy53'
 
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'py310-test-numpy122'
-            allow_failure: false
-            prefix: ''
+            prefix: 'py310-test-numpy122'
 
           - os: ubuntu-latest
             python: '3.10'
             tox_env: 'build_docs'
-            allow_failure: false
-            prefix: ''
+            prefix: 'build_docs'
             
     steps:
     - uses: actions/checkout@v3

--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 
 PetroFit
 --------
-|CI tag| |rtd tag| |PyPI tag|  |AJ tag| |astropy tag| |photutils tag|
+|CI tag| |rtd tag| |PyPI tag| |AJ tag| |zonodo tag| |astropy tag| |photutils tag|
 
 PetroFit is a package for calculating Petrosian properties, such as radii and concentration indices, as well as fitting
 galaxy light profiles. In particular, PetroFit includes tools for performing accurate photometry, segmentations,
@@ -81,3 +81,7 @@ petrofit based on its use in the README file for the
 .. |photutils tag| image:: http://img.shields.io/badge/powered%20by-Photutils-blue.svg?style=flat&colorB=084680
     :target: https://pypi.org/project/photutils/
     :alt: Powered by photutils
+
+.. |zonodo tag| image:: http://img.shields.io/badge/zenodo-10.5281/zenodo.6386991-blue.svg?style=flat
+    :target: https://zenodo.org/badge/latestdoi/348478663
+    :alt: PetroFit Zenodo DOI

--- a/README.rst
+++ b/README.rst
@@ -14,6 +14,11 @@ for installation instructions and a guide to the ``petrofit`` module.
 .. image:: https://github.com/PetroFit/petrofit/raw/main/docs/images/multi_fit.png
     :width: 100%
 
+Installation
+------------
+You can install PetroFit using ``pip install petrofit``. Please see
+the `petrofit documentation <https://petrofit.readthedocs.io/en/latest/>`_ for detailed installation instructions.
+
 License
 -------
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,14 +15,6 @@ PetroFit can be installed using pip as follows:
 
     pip install petrofit
 
-Before installing PetroFit, you may need to install the required dependencies.
-You can do this using the requirements file located in the top directory of the repository. To do so, navigate to the
-top directory of the PetroFit repository (where the requirements.txt file is located). Then run:
-
-.. code-block:: bash
-
-    pip install -r requirements.txt
-
 Conda
 *****
 
@@ -129,6 +121,14 @@ For developers, we recommend setting up a conda environment and then using the f
 
 If you will be contributing to the software, we recommend forking the repository on GitHub first, cloning your forked repository,
 and then installing the developer version.
+
+Before installing PetroFit, you may need to install the required dependencies.
+You can do this using the requirements file located in the top directory of the repository. To do so, navigate to the
+top directory of the PetroFit repository (where the requirements.txt file is located). Then run:
+
+.. code-block:: bash
+
+    pip install -r requirements.txt
 
 Frozen versions of conda environment files are provided via the `petrofit_environments repository <https://github.com/PetroFit/petrofit_environments>`_.
 

--- a/petrofit/_astropy_init.py
+++ b/petrofit/_astropy_init.py
@@ -1,52 +1,33 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 
-__all__ = ['__version__']
+__all__ = ['__version__', '__githash__']
 
 # this indicates whether or not we are in the package's setup.py
 try:
     _ASTROPY_SETUP_
 except NameError:
-    import builtins
+    from sys import version_info
+    if version_info[0] >= 3:
+        import builtins
+    else:
+        import __builtin__ as builtins
     builtins._ASTROPY_SETUP_ = False
 
 try:
     from .version import version as __version__
 except ImportError:
     __version__ = ''
+try:
+    from .version import githash as __githash__
+except ImportError:
+    __githash__ = ''
 
 
 if not _ASTROPY_SETUP_:  # noqa
     import os
-    from warnings import warn
-    from astropy.config.configuration import (
-        update_default_config,
-        ConfigurationDefaultMissingError,
-        ConfigurationDefaultMissingWarning)
 
     # Create the test function for self test
     from astropy.tests.runner import TestRunner
     test = TestRunner.make_test_runner_in(os.path.dirname(__file__))
     test.__test__ = False
     __all__ += ['test']
-
-    # add these here so we only need to cleanup the namespace at the end
-    config_dir = None
-
-    if not os.environ.get('ASTROPY_SKIP_CONFIG_UPDATE', False):
-        config_dir = os.path.dirname(__file__)
-        config_template = os.path.join(config_dir, __package__ + ".cfg")
-        if os.path.isfile(config_template):
-            try:
-                update_default_config(
-                    __package__, config_dir, version=__version__)
-            except TypeError as orig_error:
-                try:
-                    update_default_config(__package__, config_dir)
-                except ConfigurationDefaultMissingError as e:
-                    wmsg = (e.args[0] +
-                            " Cannot install default profile. If you are "
-                            "importing from source, this is expected.")
-                    warn(ConfigurationDefaultMissingWarning(wmsg))
-                    del e
-                except Exception:
-                    raise orig_error

--- a/petrofit/modeling/models.py
+++ b/petrofit/modeling/models.py
@@ -74,6 +74,10 @@ def get_default_sersic_bounds(override={}):
 
 
 def get_default_gen_sersic_bounds(override={}):
+    """
+    Returns the default bounds of a Generalized Sersic profile.
+    This is identical to `get_default_sersic_bounds` but adds a `c_0` bound.
+    """
     bounds = get_default_sersic_bounds()
     bounds['c_0'] = (0, 2.0)
     bounds.update(override)
@@ -540,13 +544,8 @@ def CoreSersic2D(x, y, amplitude=1, r_eff=1, r_break=1, n=1, x_0=0, y_0=0,
     )
 
 
-def sersic_enclosed(
-        r,
-        amplitude,
-        r_eff,
-        n,
-        ellip=0
-):
+def sersic_enclosed(r, amplitude, r_eff, n, ellip=0):
+    """Total Sersic flux enclosed within a radius."""
     bn = gammaincinv(2. * n, 0.5)
     x = bn * (r / r_eff) ** (1 / n)
     g = gamma(2. * n) * gammainc(2. * n, x)
@@ -554,13 +553,8 @@ def sersic_enclosed(
     return amplitude * (r_eff ** 2) * 2 * np.pi * n * ((np.exp(bn)) / (bn) ** (2 * n)) * g * (1 - ellip)
 
 
-def sersic_enclosed_inv(
-        f,
-        amplitude,
-        r_eff,
-        n,
-        ellip=0
-):
+def sersic_enclosed_inv(f, amplitude, r_eff, n, ellip=0):
+    """Radius that would enclose the input flux."""
     bn = gammaincinv(2. * n, 0.5)
     g = f / (amplitude * (r_eff) ** 2 * 2 * np.pi * n * ((np.exp(bn)) / (bn) ** (2 * n)) * (1 - ellip))
 
@@ -570,17 +564,13 @@ def sersic_enclosed_inv(
 
 
 @custom_model
-def sersic_enclosed_model(
-        x,
-        amplitude=1000,
-        r_eff=30,
-        n=2,
-        ellip=0,
-):
+def sersic_enclosed_model(x, amplitude=1000, r_eff=30, n=2, ellip=0):
+    """Model for total Sersic flux enclosed within a radius."""
     return sersic_enclosed(x, amplitude, r_eff, n, ellip=ellip)
 
 
 def petrosian_profile(r, r_eff, n):
+    """Ideal Sersic Petrosian profile evaluated at input radii."""
     bn = gammaincinv(2. * n, 0.5)
 
     x = bn * (r / r_eff) ** (1 / n)
@@ -591,12 +581,8 @@ def petrosian_profile(r, r_eff, n):
 
 
 @custom_model
-def petrosian_model(
-    x, 
-    r_eff=1, 
-    n=4
-
-):
+def petrosian_model(x, r_eff=1, n=4):
+    """Ideal Sersic Petrosian model."""
     return petrosian_profile(x, r_eff, n)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,6 +18,7 @@ python_requires = >=3.7
 setup_requires = setuptools_scm
 install_requires =
     numpy
+    matplotlib
     astropy
     scipy
     pyyaml


### PR DESCRIPTION
List of updates based on [pyOpenSci review](https://github.com/pyOpenSci/software-submission/issues/159#issuecomment-1962177620)
- [x]  The package should install without the use of `requirement.txt`:
    - [x]  Matplotlib was missing, I have added it.
    - [x] New versions of astropy no longer need `update_default_config`. I have removed this function call for people using pip to install.
- [x] Add zenodo badge (I see one on the [Citing and Credits](https://petrofit.readthedocs.io/en/latest/citing.html)) page in docs to README.md
- [x] Clean up docstrings in `models.py`
- [x] Update pip install instructions 
- [x] Clean up `ci_test.yml`