### PR TITLE
Update RTD to Use Python 3.11.8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ channels:
 dependencies:
   # Base dependencies
   - pip
-  - python>=3.8
+  - python==3.11.8
   - Pandoc
   - pip:
     - -r requirements.txt


### PR DESCRIPTION
Update RTD python version to 3.11.8. More work will be needed to upgrade to 3.12 since there are many backward compatibility issues. 