### PR TITLE
Prep for v0.5.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## Version 0.5.1
-*TBD*
+*August 16th 2024*
 
 **PetroFit Enhancements**
 


### PR DESCRIPTION
# Version 0.5.1
*August 16th 2024*

**PetroFit Enhancements**

- Update installation requiements for use with `python 3.12`. #209

**General bug fixes and small changes**

- Update rtd to use `ubuntu-22.04`. #200
- `update_default_config` removed since `astropy` no longer needs it. #205
- Update rtd to Use `Python 3.11.8`. #206
- Update installation requiements for use with `python 3.12`. #209
- Remove `astropy_helpers` from requirements. #209