### PR TITLE
Patch test badge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test Suite
+name: Tests
 
 on:
   workflow_dispatch: {}
@@ -46,7 +46,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          
+
       - name: Install Pandoc
         run: sudo apt-get install pandoc
 

--- a/README.rst
+++ b/README.rst
@@ -135,8 +135,8 @@ petrofit based on its use in the README file for the
 `MetPy project <https://github.com/Unidata/MetPy>`_.
 
 
-.. |CI tag| image:: https://github.com/PetroFit/petrofit/actions/workflows/ci_tests.yml/badge.svg?branch=main
-    :target: https://github.com/PetroFit/petrofit/actions/workflows/ci_tests.yml
+.. |CI tag| image:: https://github.com/PetroFit/petrofit/actions/workflows/test.yml/badge.svg?branch=main
+    :target: https://github.com/PetroFit/petrofit/actions/workflows/test.yml
     :alt: PetroFit CI status
 
 .. |rtd tag| image:: https://readthedocs.org/projects/petrofit/badge/?version=latest


### PR DESCRIPTION
This PR changes the name of the CI tests to just `test` and fixes the CI badge in the readme file. 